### PR TITLE
feat: allow overrides config by env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,46 @@ export default defineNuxtConfig({
 // GET /api/todos -> https://jsonplaceholder.typicode.com/todos [304]
 // GET /api/launches -> https://api.spacexdata.com/v5/launches/latest [304]
 ```
+### Runtime config
+
+Runtime configuration is valid if you put the configuration inside "runtimeConfig" and set your environment variables
+
+```env
+NUXT_PROXY_OPTIONS_TARGET=https://reqres.in/api
+```
+```ts
+export default defineNuxtConfig({
+  modules: ['nuxt-proxy'],
+  runtimeConfig: {
+    proxy: {
+      options: { target: 'https://jsonplaceholder.typicode.com', ...{ /* config */} }
+    }
+  }
+})
+// GET /api/users -> https://reqres.in/api/users [304]
+```
+
+Or for multiple targets
+
+```ts
+export default defineNuxtConfig({
+  modules: ['nuxt-proxy'],
+  runtimeConfig: {
+    proxy: {
+      options: [
+        { target: 'https://jsonplaceholder.typicode.com', ...{ /* config */} },
+        { target: 'https://api.spacexdata.com/v5', ...{ /* config */} },
+      ]
+    }
+  },
+})
+
+// GET /api/todos -> https://jsonplaceholder.typicode.com/todos [304]
+// GET /api/launches -> https://fake.wobsoriano.space/launches/latest [304]
+```
+```env
+NUXT_PROXY_OPTIONS=[{}, {"target": "https://fake.wobsoriano.space"}]
+```
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@nuxt/kit": "3.0.0-rc.12",
     "dedent": "^0.7.0",
+    "defu": "^6.0.0",
     "h3": "^0.8.5",
     "http-proxy-middleware": "^3.0.0-beta.0",
     "ohash": "^0.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ importers:
       '@types/dedent': ^0.7.0
       bumpp: ^8.2.1
       dedent: ^0.7.0
+      defu: ^6.0.0
       eslint: ^8.14.0
       h3: ^0.8.5
       http-proxy-middleware: ^3.0.0-beta.0
@@ -21,6 +22,7 @@ importers:
     dependencies:
       '@nuxt/kit': 3.0.0-rc.12
       dedent: 0.7.0
+      defu: 6.1.0
       h3: 0.8.5
       http-proxy-middleware: 3.0.0-beta.0
       ohash: 0.1.5
@@ -2071,9 +2073,6 @@ packages:
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
     dev: true
-
-  /defu/6.0.0:
-    resolution: {integrity: sha512-t2MZGLf1V2rV4VBZbWIaXKdX/mUcYW0n2znQZoADBkGGxYL8EWqCuCZBmJPJ/Yy9fofJkyuuSuo5GSwo0XdEgw==}
 
   /defu/6.1.0:
     resolution: {integrity: sha512-pOFYRTIhoKujrmbTRhcW5lYQLBXw/dlTwfI8IguF1QCDJOcJzNH1w+YFjxqy6BAuJrClTy6MUE8q+oKJ2FLsIw==}
@@ -5276,7 +5275,7 @@ packages:
   /rc9/1.2.2:
     resolution: {integrity: sha512-zbe8+HR2X28eZepAwohuKkebbEsA67h0DO9I7g12QrHa2CQopR9gztOLPIPXXGTvcxeUjAN4wZ+b29t3m/u05g==}
     dependencies:
-      defu: 6.0.0
+      defu: 6.1.0
       destr: 1.1.1
       flat: 5.0.2
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -5,15 +5,19 @@ import { join } from 'pathe'
 import dedent from 'dedent'
 import { hash, objectHash } from 'ohash'
 
-function createProxyMiddleware(buildDir: string, filename: string, options: Options) {
+function createProxyMiddleware(buildDir: string, filename: string, options: Options, index?: number) {
   addTemplate({
     filename,
     write: true,
     getContents: () => dedent`
       import { createProxyMiddleware } from 'nuxt-proxy/middleware'
+      import { defu } from 'defu'
       import { useRuntimeConfig } from '#imports'
 
-      export default createProxyMiddleware(${JSON.stringify(options)})
+      const buildtimeOptions = ${JSON.stringify(options)}
+      const runtimeOptions = [].concat(useRuntimeConfig().proxy?.options)[${JSON.stringify(index)} ?? 0]
+
+      export default createProxyMiddleware(defu(runtimeOptions, buildtimeOptions))
     `,
   })
 
@@ -43,9 +47,9 @@ export default defineNuxtModule<ModuleOptions>({
     const finalConfig = (nuxt.options.runtimeConfig.proxy = nuxt.options.runtimeConfig.proxy || { options: options.options }) as ModuleOptions
 
     if (Array.isArray(finalConfig.options)) {
-      finalConfig.options.forEach((options) => {
+      finalConfig.options.forEach((options, index) => {
         const filename = `proxy/handler_${hash(objectHash(options))}.ts`
-        createProxyMiddleware(nuxt.options.buildDir, filename, options)
+        createProxyMiddleware(nuxt.options.buildDir, filename, options, index)
       })
     }
     else {


### PR DESCRIPTION
Hi

You have merged my contribution, but you have removed its main benefit.

The need addressed is to be able to override the proxy configuration at runtime. This way it is possible to compile with default options and then run it with options adapted to the execution environment.

I understood what you tried to do by allowing the use of the "runtimeConfig" configuration in "nuxt.config.ts". So here is a new contribution that takes up what I understood from your idea and my initial need.

Now its possible to use :
```env
NUXT_PROXY_OPTIONS=[{}, {"target": "http://proxy.target.for/second/proxy"}]
# NUXT_PROXY_OPTIONS_TARGET=http://target.for/single-proxy
```